### PR TITLE
Updated news templates with categories

### DIFF
--- a/news-templates/event-report.md
+++ b/news-templates/event-report.md
@@ -1,6 +1,6 @@
 ---
 title: "Headline"
-tags: trip-report
+categories: event-report
 ---
 
 Paragraph(s) explaining what the event was (name/nickname), where it was held, and what its purpose was. Indicate that LLNL staff were there, including information such as how many attended, what the technical tracks were, or other explanatory information. Link to a recap on a relevant LLNL website and/or a list of LLNL's presence on committees or in the technical program. File naming convention is yyyy-mm-dd-eventrecap.md.

--- a/news-templates/event.md
+++ b/news-templates/event.md
@@ -1,6 +1,6 @@
 ---
 title: "Headline"
-tags: event
+categories: event
 ---
 
 Paragraph(s) summarizing what the event is (name/nickname), where it will be held, and what its purpose is. Indicate that LLNL staff are attending and any other contextual information. Link to a list of LLNL's presence on committees or in the technical program, if available, or link to the event's technical program. File naming convention is yyyy-mm-dd-title.md.

--- a/news-templates/multimedia.md
+++ b/news-templates/multimedia.md
@@ -1,6 +1,6 @@
 ---
 title: "Multimedia Type: Title"
-tags: multimedia
+categories: multimedia
 ---
 
 Paragraph(s) explaining what type of multimedia is being referenced (e.g., video, podcast), which LLNL staff are featured in it, and what it has to do with open source software. Link to the multimedia object by indicating what plaform it is accessed on (e.g., YouTube) and how long it is (mm:ss). Link to any other relevant content, such as a GH repo or a LLNL web page. File naming convention is yyyy-mm-dd-title.md.

--- a/news-templates/new-release.md
+++ b/news-templates/new-release.md
@@ -1,6 +1,6 @@
 ---
 title: "Repo X.X.X Released"
-tags: new-release
+categories: new-release
 ---
 
 Repo (GH link) is ... a few sentences from the repo's README or documentation. The goal is to explain what the software does, what problem it solves, or what use case it serves. File naming convention is yyyy-mm-dd-repo-x.x.x.md where X.X.X is the version number.

--- a/news-templates/new-repo.md
+++ b/news-templates/new-repo.md
@@ -1,6 +1,6 @@
 ---
 title: "New Repo: Repo Name"
-tags: new-repo
+categories: new-repo
 ---
 
 Repo (GH link) is ... a few sentences from the repo's README or documentation. The goal is to explain what the software does, what problem it solves, or what use case it serves. See the documentation (link to it) for more information. File naming convention is yyyy-mm-dd-repo-new.md.

--- a/news-templates/profile.md
+++ b/news-templates/profile.md
@@ -1,6 +1,6 @@
 ---
 title: "Headline with Person's Name"
-tags: profile
+categories: profile
 ---
 
 Paragraph(s) summarizing  who the person is, why they are notable, and what the profile highlights or focuses on (e.g., career, a major milestone, education). Provide context for what the person does at LLNL relevant to open source software. Link to the publication/article about the person and any other relevant items, such as a GH repo. File naming convention is yyyy-mm-dd-lastname.md.

--- a/news-templates/story.md
+++ b/news-templates/story.md
@@ -1,6 +1,6 @@
 ---
 title: "Headline"
-tags: story
+categories: story
 ---
 
 Paragraph(s) summarizing the news story (e.g., award received), which LLNL staff are featured, and what it has to do with open source software. Link to the news story any other relevant content, such as a GH repo or a LLNL web page. File naming convention is yyyy-mm-dd-title.md.

--- a/news-templates/this-website.md
+++ b/news-templates/this-website.md
@@ -1,6 +1,6 @@
 ---
 title: "Headline Mentioning New Features"
-tags: this-website
+categories: this-website
 ---
 
 Paragraph(s) summarizing what is new about this website (software.llnl.gov), such as a new page, type of browse, set of content, or enhancement to user experience. This type of post could also be used to call attention to stats from the Explore page or a milestone achieved at LLNL that is integrated into, or showcased on, the website. File naming convention is yyyy-mm-dd-title.md.


### PR DESCRIPTION
1. Replaced `tags` with `categories` in news post templates
2. Renamed `trip-report` as `event-report` (a change that was done earlier on llnl.github.io but not reflect here yet)