### PR TITLE
Updated Resources links

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -2,9 +2,9 @@
 
 .. _resources:
 
-======================
-RtD & Sphinx Resources
-======================
+=======================
+Documentation Resources
+=======================
 
 These sites are good places to learn about Read the Docs (RtD), Sphinx, and all the things you can do in .rst files:
 
@@ -15,3 +15,12 @@ These sites are good places to learn about Read the Docs (RtD), Sphinx, and all 
 * `Sphinx tutorial <https://sphinx-tutorial.readthedocs.io/>`_
 * `reStructuredText Primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
 * `Graphviz syntax <https://rich-iannone.github.io/DiagrammeR/graphviz_and_mermaid.html>`_
+
+To write more effective software documentation generally, here are some useful sites:
+
+* The `18F Content Guide <https://content-guide.18f.gov/>`_ houses best practices for software documentation focused on user experiences and needs, particularly as related to government websites.
+* `Write the Docs <https://www.writethedocs.org/>`_, a community focused on communication and documentation, has a `catalog of learning resources <https://www.writethedocs.org/about/learning-resources/>`_ (including videos and tutorials) as well as a robust `documentation guide <https://www.writethedocs.org/guide/>`_. This community also has a `GitHub repo <https://github.com/writethedocs>`_.
+* `Docs as Code <https://www.docslikecode.com/>`_ provides resources for development teams to build documentation repeatably and consistently across multiple platforms.
+* The `Documentation System <https://documentation.divio.com/>`_ emphasizes four types of documentation: tutorials, how-to guides, technical reference, and explanation documents. The site provides examples of and tips for each.
+* The `Good Docs Project <https://thegooddocsproject.dev/>`_, to which you can `contribute <https://thegooddocsproject.dev/contribute>`_, includes templates and writing instructions for documenting open source software. The organization's templates go through a rigorous writing, reviewing, and refining process.
+* The `Beautiful Docs repo <https://github.com/PharkMillups/beautiful-docs>`_ has a list of language- and program-specific documentation resources.

--- a/docs/setup_steps.rst
+++ b/docs/setup_steps.rst
@@ -69,7 +69,7 @@ This process generates a **readthedocs.io** URL for your project, which you can 
 
 6. Confirm that docs still build locally, then open and merge PR.
 7. On your RtD dashboard, select the project and initiate a build to test: Projects > your repo > Builds > Build Version.
-8. You may want to change some of RtD's advanced settings, such as specifying which version is considered "latest" or which branch is the default. Projects > your repo > Admin > Advanced Settings. 
+8. You may want to change some of RtD's advanced settings, such as specifying which version is considered "latest" or which branch is the default. Don't forget to update this area if you change the name of your default branch (e.g., ``master`` to ``main``). Projects > your repo > Admin > Advanced Settings. 
 
 ---------------------------------
 E. Create and Populate .rst Files


### PR DESCRIPTION
Closes #31 
Adds more resource links specifically about _documentation_ best practices, templates, and guidelines. Also updates that file's title and adds a note about updating RtD settings when a branch name changes, which is why my build failed on the last PR.