### PR TITLE
Edits to two templates for accessibility

### DIFF
--- a/news-templates/event-report.md
+++ b/news-templates/event-report.md
@@ -3,4 +3,4 @@ title: "Headline"
 categories: event-report
 ---
 
-Paragraph(s) explaining what the event was (name/nickname), where it was held, and what its purpose was. Indicate that LLNL staff were there, including information such as how many attended, what the technical tracks were, or other explanatory information. Link to a recap on a relevant LLNL website and/or a list of LLNL's presence on committees or in the technical program. File naming convention is yyyy-mm-dd-eventrecap.md.
+Paragraph(s) explaining what the event was (name/nickname), where it was held, and what its purpose was. Indicate that LLNL staff were there, including information such as how many attended, what the technical tracks were, or other explanatory information. Link to a recap on a relevant LLNL website and/or a list of LLNL's presence on committees or in the technical program. File naming convention is yyyy-mm-dd-eventrecap.md (or similar).

--- a/news-templates/release.md
+++ b/news-templates/release.md
@@ -10,7 +10,9 @@ This release includes several news features, such as:
 - Etc.
 
 Learn more:
-- Release notes (link to GH release tag)
-- GitHub repo (GH link)
-- Documentation/user guide/tutorial (link)
+- Project vX.X.X release notes (link to GH release tag)
+- Project GitHub repo (GH link)
+- Project documentation/user guide/tutorial (link)
 - Any other related link (e.g., news article, video, web page)
+
+*Note:* Link text must be unique, or else the News pages (where posts are viewed in aggregate) will not be accessible to all users. For example, put the project name and version number in the link text for the release notes.


### PR DESCRIPTION
News about releases should have unique link text so, e.g., "release notes" does not appear as a bunch of different links with the same link text on https://software.llnl.gov/news/ and https://software.llnl.gov/news/archive/